### PR TITLE
Upgrade graphql-js to the latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "bluebird": "^3.5.0",
     "fs-extra": "^0.30.0",
     "glob": "^7.1.0",
-    "graphql": "^0.7.0",
+    "graphql": "^0.11.7",
     "marked": "^0.3.6",
     "mustache": "^2.2.1",
     "request": "^2.79.0",


### PR DESCRIPTION
Was running into a problem where GraphQL wasn't outputting decent error messages whenever using a custom schema (specific error I was getting was "Expected Input type", which isn't useful at all).

In later versions of GraphQL, the error message has since been improved. I upgraded the version of graphql-js in the package to the latest version and the tests seemed to run without problem.

**Edit:** It appears the builds are failing because of TypeScript. I was able to get the TypeScript to compile locally (somehow) and use it with success in my own code. I got the same error on `master` so the failures seem unrelated to this PR.