### PR TITLE
Update @types packages and fix options merge

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -195,7 +195,7 @@ export class GraphQLDocumentor extends Command<Flags, Params> {
             packageJSON = {};
         }
 
-        packageJSON.graphdoc = deepmerge(packageJSON.graphdoc || {}, input.flags);
+        packageJSON.graphdoc = deepmerge(input.flags, packageJSON.graphdoc || {});
 
         if (packageJSON.graphdoc.data) {
             const data = packageJSON.graphdoc.data;

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as glob from 'glob';
 import { render } from 'mustache';
+import * as deepmerge from 'deepmerge';
 import { Output, Plugin, getFilenameOf, createData } from './utility';
 import { readFile, writeFile, createBuildDirectory, resolve, removeBuildDirectory } from './utility/fs';
 import {
@@ -194,11 +195,11 @@ export class GraphQLDocumentor extends Command<Flags, Params> {
             packageJSON = {};
         }
 
-        packageJSON.graphdoc = Object.assign(packageJSON.graphdoc || {}, input.flags);
+        packageJSON.graphdoc = deepmerge(packageJSON.graphdoc || {}, input.flags);
 
         if (packageJSON.graphdoc.data) {
             const data = packageJSON.graphdoc.data;
-            packageJSON.graphdoc = Object.assign(data, packageJSON.graphdoc);
+            packageJSON.graphdoc = deepmerge(data, packageJSON.graphdoc);
         }
 
         if (packageJSON.graphdoc.plugins.length === 0)

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "@types/marked": "0.0.27",
     "@types/mocha": "^2.2.32",
     "@types/mustache": "^0.8.28",
-    "@types/node": "^6.0.32",
-    "@types/request": "^0.0.40",
-    "@types/striptags": "^0.0.5",
+    "@types/node": "^9.4.6",
+    "@types/request": "^2.47.0",
+    "@types/striptags": "^3.1.1",
     "chai": "^3.5.0",
     "handlebars": "^4.0.10",
     "jest": "^18.1.0",
@@ -56,6 +56,7 @@
   "dependencies": {
     "@2fd/command": "^1.1.2",
     "bluebird": "^3.5.0",
+    "deepmerge": "^2.0.1",
     "fs-extra": "^0.30.0",
     "glob": "^7.1.0",
     "graphql": "^0.7.0",
@@ -63,7 +64,7 @@
     "mustache": "^2.2.1",
     "request": "^2.79.0",
     "slug": "^0.9.1",
-    "striptags": "^3.0.1",
+    "striptags": "^3.1.1",
     "word-wrap": "^1.2.1"
   },
   "graphdoc": {

--- a/plugins/document.require-by/index.ts
+++ b/plugins/document.require-by/index.ts
@@ -18,7 +18,7 @@ import {
 } from '../../lib/interface';
 
 // Fix signature
-const stript: typeof striptags.default = striptags as any;
+const stript: typeof striptags = striptags as any;
 
 export default class RequireByPlugin extends Plugin implements PluginInterface {
 


### PR DESCRIPTION
Currently the options in `package.json` is not correctly merged, because `Object.assign` only does shallow merge and thus any `headers` options is ignored.
This make the current version fails to generate documention for protected endpoints that require `Authorization` header because the `headers` option is not included.

This PR fixs that by using `deepmerge` package to correctly incorporate the `package.json` options into the default options object.