### PR TITLE
doc: fixed heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ npm install -g @2fd/graphdoc
 > graphdoc -s ./schema.graphql -o ./doc/schema
 ```
 
-### Generate documentation from for the ["modularized
-
-schema"](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html#modularizing) of graphql-tools
+### Generate documentation from for the ["modularized schema"](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html#modularizing) of graphql-tools
 
 ```bash
 > graphdoc -s ./schema.js -o ./doc/schema


### PR DESCRIPTION
Fixed link in "Generate documentation from for the "modularized schema" of graphql-tools". The "modularized schema" link was previously split into 2 lines.