### PR TITLE
doc: fix formatting issue in README.md

### DIFF
--- a/README.handlebars
+++ b/README.handlebars
@@ -40,9 +40,7 @@ npm install -g @2fd/graphdoc
 > graphdoc -s ./schema.graphql -o ./doc/schema
 ```
 
-### Generate documentation from for the ["modularized
-
-schema"](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html#modularizing) of graphql-tools
+### Generate documentation from for the ["modularized schema"](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html#modularizing) of graphql-tools
 
 ```bash
 > graphdoc -s ./schema.js -o ./doc/schema

--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ npm install -g @2fd/graphdoc
 > graphdoc -s ./schema.graphql -o ./doc/schema
 ```
 
-### Generate documentation from for the ["modularized
-
-schema"](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html#modularizing) of graphql-tools
+### Generate documentation from for the ["modularized schema"](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html#modularizing) of graphql-tools
 
 ```bash
 > graphdoc -s ./schema.js -o ./doc/schema


### PR DESCRIPTION
It looks like a newline/whitespace was mistakenly inserted by a non-markdown-aware auto-formatting operation in https://github.com/2fd/graphdoc/commit/8ef7a0faaf90569536c36c363c7b33bac217da10