### PR TITLE
CI: Remove unsupported node releases (6.x, 8.x)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Node 6 and 8 are no longer supported

Node 10 expires April 30th 2021

Source: https://nodejs.org/en/about/releases/
![image](https://user-images.githubusercontent.com/26336/105642877-1b1ac300-5e52-11eb-959e-e9e0563b62f5.png)


Also: Should allow #304, #305