### PR TITLE
Add default values and fix empty descriptions renderings

### DIFF
--- a/plugins/document.require-by/index.ts
+++ b/plugins/document.require-by/index.ts
@@ -95,6 +95,7 @@ export default class RequireByPlugin extends Plugin implements PluginInterface {
   }
 
   getDescription(type: SchemaType): string {
+    const description = type.description || "";
     return (
       "<li>" +
       '<a href="' +
@@ -102,11 +103,11 @@ export default class RequireByPlugin extends Plugin implements PluginInterface {
       '" title="' +
       type.name +
       " - " +
-      striptags(type.description || "").replace(/"/gi, "&quot;") +
+      striptags(description).replace(/"/gi, "&quot;") +
       '">' +
       type.name +
       "<em>" +
-      type.description +
+      description +
       "</em>" +
       "</a>" +
       "<li>"

--- a/plugins/document.schema/index.ts
+++ b/plugins/document.schema/index.ts
@@ -103,6 +103,7 @@ export default class SchemaPlugin extends Plugin implements PluginInterface {
       this.html.property(arg.name) +
       ": " +
       this.html.useIdentifier(arg.type, this.url(arg.type)) // + ' ' + this.deprecated(arg);
+      + this.defaultValue(arg)
     );
   }
 
@@ -333,12 +334,22 @@ export default class SchemaPlugin extends Plugin implements PluginInterface {
       .concat(argDescription)
       .concat([
         this.html.property(arg.name) +
-          ": " +
-          this.html.useIdentifier(arg.type, this.url(arg.type)) // + ' ' + this.deprecated(arg)
+        ": " +
+        this.html.useIdentifier(arg.type, this.url(arg.type)) // + ' ' + this.deprecated(arg)
+        + this.defaultValue(arg)
       ])
       .map(line => this.html.line(this.html.tab(line)))
       .join("");
   }
+
+  defaultValue(input: InputValue) {
+    if (input.defaultValue === null) {
+      return "";
+    }
+
+    return " = " + input.defaultValue;
+  }
+
 
   interfaces(type: SchemaType): string {
     return (


### PR DESCRIPTION
This PR contains 2 changes:

First, if an item or a node doesn't have a description, the actual value in the AST might be `null`. 
There was a small bug about not casting the value to an empty string, so `null` would be rendered on the web page.

Second, arguments and input values might have a default value, which I believe should be reflected in the docs.
I added a simple piece of code rendering that like `limit: Int = 10`.

Cheers!